### PR TITLE
ssl: Support TLS SNI extension

### DIFF
--- a/src/ssl.c
+++ b/src/ssl.c
@@ -65,7 +65,7 @@ struct uwsc_ssl_ctx {
 
 #endif
 
-int uwsc_ssl_init(struct uwsc_ssl_ctx **ctx, int sock)
+int uwsc_ssl_init(struct uwsc_ssl_ctx **ctx, int sock, char *host)
 {
     struct uwsc_ssl_ctx *c = calloc(1, sizeof(struct uwsc_ssl_ctx));
 
@@ -93,6 +93,7 @@ int uwsc_ssl_init(struct uwsc_ssl_ctx **ctx, int sock)
 
     mbedtls_ssl_set_bio(&c->ssl, &c->net, mbedtls_net_send,
         mbedtls_net_recv, NULL);
+    mbedtls_ssl_set_hostname(&c->ssl, host);
 
     mbedtls_ssl_setup(&c->ssl, &c->cfg);
 
@@ -111,8 +112,8 @@ int uwsc_ssl_init(struct uwsc_ssl_ctx **ctx, int sock)
     c->ctx = SSL_CTX_new(TLS_client_method());
 #endif
     SSL_CTX_set_verify(c->ctx, SSL_VERIFY_NONE, NULL);
-
     c->ssl = SSL_new(c->ctx);
+    SSL_set_tlsext_host_name(c->ssl, host);
     SSL_set_fd(c->ssl, sock);
 #endif
 

--- a/src/ssl.h
+++ b/src/ssl.h
@@ -34,7 +34,7 @@
 
 struct uwsc_ssl_ctx;
 
-int uwsc_ssl_init(struct uwsc_ssl_ctx **ctx, int sock);
+int uwsc_ssl_init(struct uwsc_ssl_ctx **ctx, int sock, char *host);
 int uwsc_ssl_handshake(struct uwsc_ssl_ctx *ctx);
 void uwsc_ssl_free(struct uwsc_ssl_ctx *ctx);
 

--- a/src/uwsc.c
+++ b/src/uwsc.c
@@ -616,10 +616,9 @@ int uwsc_init(struct uwsc_client *cl, struct ev_loop *loop, const char *url,
     cl->free = uwsc_free;
     cl->start_time = ev_now(cl->loop);
     cl->ping_interval = ping_interval;
-
     if (ssl) {
 #if (UWSC_SSL_SUPPORT)
-        uwsc_ssl_init((struct uwsc_ssl_ctx **)&cl->ssl, cl->sock);
+        uwsc_ssl_init((struct uwsc_ssl_ctx **)&cl->ssl, cl->sock, host);
 #else
         uwsc_log_err("SSL is not enabled at compile\n");
         uwsc_free(cl);


### PR DESCRIPTION
Support SNI in TLS client can fix the problem which I have mentioned in  the project Rttys #30  
I have tested this change compatible with previous versions.